### PR TITLE
Trac 1.0 compatibility fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+*.sln    merge=union
+*.csproj merge=union
+*.vbproj merge=union
+*.fsproj merge=union
+*.dbproj merge=union
+
+# Standard to msysgit
+*.doc	 diff=astextplain
+*.DOC	 diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF	 diff=astextplain
+*.rtf	 diff=astextplain
+*.RTF	 diff=astextplain


### PR DESCRIPTION
My knowledge of Python and the Trac internals are minimal, so these changes represent only what was needed to get required the plugin to start up under Trac 1.0. I can't guarantee that there aren't further compatibility issues lurking in the code.
- Pass the context to the MimeView renderer rather than the request. Appears related to
  http://trac.edgewall.org/wiki/TracDev/ContextRefactoring and changeset [10328].
- Use the 'rev' property of revision control nodes rather than '_requested_rev' as per Trac #10208, changeset [10914].
- Added 'Content-Length' header as per [8609].

---

The .gitattributes file is included in the commit only to avoid CR/LF wierdness when committing from Github for Windows. They're the github recommended settings, but feel free to ignore.
